### PR TITLE
(bugFix): 403 error when starting the server

### DIFF
--- a/server/controller/todos.js
+++ b/server/controller/todos.js
@@ -5,9 +5,9 @@ export const readTodos = async(req,res) => {
 
     try {
         const todos =  await Todo.find();
-        res.Status(200).json(todos);
+        res.status(200).json(todos);
     } catch (error) {
-        res.Status(404).json({ error: error.message});
+        res.status(404).json({ error: error.message});
     }
 
 }
@@ -16,9 +16,9 @@ export const createTodos = async(req,res) => {
     const todo = new Todo(req.body);
     try {
         await todo.save();
-        res.Status(201).json(todo);
+        res.status(201).json(todo);
     } catch (error) {
-        res.Status(409).json({ error: error.message});
+        res.status(409).json({ error: error.message});
     }
 
 }

--- a/server/index.js
+++ b/server/index.js
@@ -14,12 +14,21 @@ app.use('/todos',todosRouter);
 const mongodb = "mongodb+srv://aaran:alpha@cluster0.grkodfd.mongodb.net/todos-database?retryWrites=true&w=majority";
 
 app.get('/', (req,res) => {
-    res.send('Welcome to server');
+    res.send('Welcome to servers');
 
 })
 
 const PORT = process.env.PORT || 5000;
 
 mongoose.connect(mongodb, { useUnifiedTopology: true }, { useNewUrlParser: true } )
-    .then( () => console.log(`server is running on port ${PORT}`))
+    .then( () => {
+        console.log("Connected to MongoDB");
+
+        app.listen(PORT, () => {
+            console.log(`Server is running on port ${PORT}`);
+          });
+
+    })
     .catch( err => console.log(err));
+
+


### PR DESCRIPTION
- When starting the server on a MacBook Air on port 5000, a 403 error was thrown.
- This was due to two reasons: Apple's Airplay Reciever was listening on Port 5000 and contrary to my prior research, the mongodb.connect() function did not actually start the app.
- To resolve these issues, the AirPlay Receiver was turned off in the computer's settings and the app.listen() function was added to start the server.